### PR TITLE
Add Transfer Out Fee Process Feature

### DIFF
--- a/features/transfer_out_fee_process.feature
+++ b/features/transfer_out_fee_process.feature
@@ -1,0 +1,35 @@
+Feature: Transfer Out Fee Process
+  This feature describes the scenarios for determining and applying transfer-out fees based on various conditions.
+
+  Scenario: Start Process
+    Given I open "Transfer Fee Page" url
+    When I execute "Determine Transfer Out Fee" function
+    And I execute "Determine No Charge Default Scenario(s)" function
+    Then I execute "Trigger External Transfer Out Fee" function
+    And I expect text of "process_status_label" to be equal "Transfer Out Fee Determined"
+
+  Scenario: Waive Fee
+    Given I open "Transfer Fee Page" url
+    When I execute "Determine Transfer Out Fee" function
+    And I execute "Determine No Charge Default Scenario(s)" function
+    Then I execute "Waive Fee Decision" function
+    And I expect text of "process_status_label" to (be equal|contain) "Fee Waived"
+
+  Scenario: Advisor Discretion
+    Given I open "Transfer Fee Page" url
+    When I execute "Determine Transfer Out Fee" function
+    And I type "specific criteria" to "advisor_discretion_input"
+    Then I execute "Waive Fee Decision" function
+    And I expect text of "process_status_label" to (be equal|contain) "Fee Waived"
+
+  Scenario: System Defaults
+    Given I open "Transfer Fee Page" url
+    When I execute "System Default Action" function
+    Then I execute "Waive Fee Decision" function
+    And I expect text of "process_status_label" to (be equal|contain) "Fee Waived"
+
+  Scenario: External Transfer Fee
+    Given I open "Transfer Fee Page" url
+    When I execute "Determine Transfer Out Fee" function
+    Then I execute "Trigger External Transfer Out Fee" function
+    And I expect text of "process_status_label" to be equal "Transfer Out Fee Determined"


### PR DESCRIPTION
This pull request adds a new feature file `transfer_out_fee_process.feature` which describes the scenarios for determining and applying transfer-out fees based on various conditions. The scenarios include:

1. Start Process
2. Waive Fee
3. Advisor Discretion
4. System Defaults
5. External Transfer Fee

Each scenario is logically structured to focus on specific flows or decision points.